### PR TITLE
Design overhaul of progress page

### DIFF
--- a/EXP-Client/App.js
+++ b/EXP-Client/App.js
@@ -44,12 +44,12 @@ function testData() {
   ];
 
   const pastLists = [
-    { date: '3/31/2023'},
-    { date: '3/30/2023'},
-    { date: '3/28/2023'},
-    { date: '3/27/2023'}
+    { date: '2023-04-20T00:00:00.000Z' },
+    { date: '2023-04-21T00:00:00.000Z' },
+    { date: '2023-04-22T00:00:00.000Z' },
+    { date: '2023-04-23T00:00:00.000Z' }
   ];
-  
+
   return (todos, stories, pastLists)
 };
 

--- a/EXP-Client/progress/Progress.js
+++ b/EXP-Client/progress/Progress.js
@@ -8,42 +8,49 @@ import {
   View,
 } from 'react-native';
 import { MaterialIcons } from '@expo/vector-icons';
+import { Appbar, List, DataTable } from 'react-native-paper';
 
-function HeaderText() {
+function ProgressItem() {
   return (
-    <View style={styles.headerText}>
-      <Text style={{ fontSize: 20 }}>Progress</Text>
+    <View>
+      <Text>Completed tasks: your mom</Text>
+      <Text>Unfinished tasks: your dad</Text>
     </View>
   );
 }
 
 function ProgressList({ pastLists }) {
+  console.log(pastLists);
+  const [expanded, setExpanded] = React.useState(true);
+
+  const handlePress = () => setExpanded(!expanded);
   return (
     <SafeAreaView>
       <ScrollView bounces={false}>
-        {pastLists.map(({ date }) => (
-          <View key={date} style={styles.entry}>
-            <View style={styles.checkbox}>
-              <MaterialIcons name="date-range" size={30} color="black" />
-            </View>
-            <View>
-              <Text style={{ fontSize: 20 }}>{date}</Text>
-            </View>
-          </View>
-        ))}
+        <List.AccordionGroup>
+          {pastLists.map(({ _id, date }, index) => (
+            <List.Accordion id={_id} style={styles.entry}
+              title={new Date(date).toDateString()}
+              left={props => <MaterialIcons name="date-range" size={30} color="black" />}
+              expanded={expanded}
+              onPress={handlePress}>
+              <List.Item title={<ProgressItem />}></List.Item>
+            </List.Accordion>
+          ))}
+        </List.AccordionGroup>
       </ScrollView>
     </SafeAreaView>
   );
 }
 
-export default function Progress ({ pastLists }) {
+export default function Progress({ pastLists }) {
   const [isPanelActive, setIsPanelActive] = React.useState(false);
   return (
     <Provider>
       <View style={styles.content}>
-        <View style={styles.header}>
-          <HeaderText/>
-        </View>
+        <Appbar.Header elevated>
+          <Appbar.Content title="Progress" />
+        </Appbar.Header>
         <ProgressList pastLists={pastLists} />
       </View>
     </Provider>
@@ -85,9 +92,7 @@ const styles = StyleSheet.create({
   },
   entry: {
     alignItems: 'center',
-    height: 60,
-    flexDirection: 'row',
-    backgroundColor: '#D9D9D9',
-    borderBottomWidth: 1,
-  }
+    minHeight: 75,
+    flexDirection: 'row'
+  },
 });

--- a/EXP-Client/todo/TodoList.js
+++ b/EXP-Client/todo/TodoList.js
@@ -28,20 +28,9 @@ export default function TodoList({ todos, setIsPanelActive, setViewingTodo }) {
           {todos.map(({ name, deadline, priority, completed }, index) => (
             <DataTable.Row key={name} style={styles.entry}>
               <DataTable.Cell style={{ justifyContent: 'center', flex: 1 }}>
-                {/* TODO: Need to set todos w/ backend
-                      onValueChange={(check) => {
-                        todos = [
-                          ...todos.slice(0, index),
-                          { name, deadline, check },
-                          ...todos.slice(index + 1)
-                        ]
-                      }}*/}
-                <Checkbox
-                  value={completed} />
+                <Checkbox value={completed} />
               </DataTable.Cell>
-              <Pressable style={{ flex: 5 }} onPress={() => {
-                setViewingTodo({ name, deadline, priority, completed });
-              }}>
+              <Pressable style={{ flex: 5 }} onPress={() => setViewingTodo({ name, deadline, priority, completed })}>
                 <Text multiline style={{ fontSize: 20 }}>{name}</Text>
                 <Text style={{ fontSize: 10 }}>{new Date(deadline).toDateString()}</Text>
               </Pressable>


### PR DESCRIPTION
Redesigned the progress page using material principles. Implemented accordions to show progress details, since the page seems to have been static beforehand, and there was no accompanying page to display progress items.

![image](https://user-images.githubusercontent.com/31319479/235333215-6d0f229f-d665-4da2-94ea-da4ee1686124.png)